### PR TITLE
chore: fix typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.semantic_release]
 version_variable = "snapshot_queries/__init__.py:VERSION"
-branch = "jprieto/update-project-setup"
+branch = "main"


### PR DESCRIPTION
Fixes a typo in pyproject.toml that was causing failures of semantic release tool.
