### PR TITLE
refactor: switch to pytest for sqlalchemy tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,10 +26,10 @@ development =
     snapshottest==0.5.1
     pytest==7.1.1
     psycopg2-binary==2.8.6
-    ipdb;
+    ipdb
 linting =
-    black==22.3.0;
-    flake8==4.0.1;
+    black==22.3.0
+    flake8==4.0.1
     isort==5.10.1
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,15 @@ install_requires =
     pygments>=2.8.1
 
 [options.extras_require]
-development = snapshottest==0.5.1;  psycopg2-binary==2.8.6;  nose==1.3.7;  ipdb;
-linting = black==22.3.0; flake8==4.0.1; isort==5.10.1
+development =
+    snapshottest==0.5.1
+    pytest==7.1.1
+    psycopg2-binary==2.8.6
+    ipdb;
+linting =
+    black==22.3.0;
+    flake8==4.0.1;
+    isort==5.10.1
 
 [flake8]
 ignore = E501,W503

--- a/tests/test_sqlalchemy/test.sh
+++ b/tests/test_sqlalchemy/test.sh
@@ -2,4 +2,4 @@
 # cd to the directory this script lives in
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
-nosetests -s . "$@"
+pytest -s . "$@"


### PR DESCRIPTION
### Changes

- This PR changes our automated `sqlalchemy` tests to use [`pytest`](https://docs.pytest.org/en/7.1.x/) instead of [`nose`](https://nose.readthedocs.io/en/latest/)

### Why?

- I'm planning to add a `pytest` plugin to this library for query snapshot testing. This change will make this plugin testable

### Additional Minor Changes

- This PR updates our `setup.cfg` file to install `pytest` instead of `nose`. In addition, this PR updates the file to list all development and linting requirements on separate lines for better PR diffs in the future but to also provide better `git blame` reports

### Not in this PR

- No updates to the current tests in this PR. `pytest` supports non-`unittest`test cases, but this PR doesn't update our current tests to use this style. This will be done in a later PR since this will be needed to test the library's `pytest` plugin
- Not changing our Django tests to run with `pytest`. There is a [`pytest-django`](https://pytest-django.readthedocs.io/en/latest/) library which is supposed to add support for `pytest` functional testing to Django, but I have not tested this and it's out-of-scope for this PR

### What is the worse-case scenario for this PR, and why should we not worry about this?

**The tests could silently fail**

In theory, this PR could pass our github test actions but not actually fail. I don't think this is a legitimate concern, since locally I was seeing test failures running pytest when I did not have sqlalchemy installed.

**The tests could not actually be discovered**

In theory, `pytest` may be failing to find the existing `sqlalchemy` tests in this PR. The I don't think this is a legitimate concern, since the [`checks`](https://github.com/cedar-team/snapshot-queries/pull/21/checks) on this PR confirm that tests from the `tests/sqlalchemy` folder are running:

<img width="1116" alt="Screen Shot 2022-04-17 at 3 57 43 PM" src="https://user-images.githubusercontent.com/17055383/163730262-03582bfe-9e99-4095-8620-9caca79c8619.png">

