### PR TITLE
refactor: Test Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
     steps:
       - uses: actions/checkout@v3
       - name: Build image for Python ${{ matrix.python-version }}

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ print_in_cyan() {
     printf "\x1B[36m%b\x1B[0m\n" "$*"
 }
 
-PYTHON_VERSIONS=('3.8' '3.9')
+PYTHON_VERSIONS=('3.10')
 SNAPSHOT_UPDATE="--snapshot-update"
 
 for arg in "$@"; do

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     django-and-sqlalchemy
     sqlalchemy{12,13,14}-only
-    django{20,21,22,32,40}-only
+    django{21,22,32,40}-only
 isolated_build = True
 
 [testenv:django-and-sqlalchemy]
@@ -26,7 +26,6 @@ deps =
 commands = {toxinidir}/tests/test_django/test.sh --no-input {posargs}
 extras = development
 deps =
-    django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2<2.3
     django32: django>=3.2<3.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     django-and-sqlalchemy
-    sqlalchemy{10,11,12,13,14}-only
-    django{111,20,21,22,32,40}-only
+    sqlalchemy{12,13,14}-only
+    django{20,21,22,32,40}-only
 isolated_build = True
 
 [testenv:django-and-sqlalchemy]
@@ -14,21 +14,18 @@ deps =
     django>=2.2
     sqlalchemy>=1.4
 
-[testenv:sqlalchemy{10,11,12,13,14}-only]
+[testenv:sqlalchemy{12,13,14}-only]
 commands = {toxinidir}/tests/test_sqlalchemy/test.sh {posargs}
 extras = development
 deps =
-    sqlalchemy10: sqlalchemy>=1.0,<1.1
-    sqlalchemy11: sqlalchemy>=1.1,<1.2
     sqlalchemy12: sqlalchemy>=1.2,<1.3
     sqlalchemy13: sqlalchemy>=1.3,<1.4
     sqlalchemy14: sqlalchemy>=1.4,<1.5
 
-[testenv:django{111,20,21,22,32,40}-only]
+[testenv:django{20,21,22,32,40}-only]
 commands = {toxinidir}/tests/test_django/test.sh --no-input {posargs}
 extras = development
 deps =
-    django111: django>=1.11,<2.0
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2<2.3


### PR DESCRIPTION
### Changes

- This PR changes the default Python version for our `test.sh` file to 3.10
- Changes our github action to test Python 3.10 in addition to 3.8 and 3.9

### Why?

- Python 3.10 is the latest minor version of Python, so our library should support it

### Deprecations

- I'm deprecating testing of Django <= 2.0 and SQLAlchemy <= 1.1 since these versions are broken in Python 3.10. While the library should still work with these versions, I did not update our testing matrix to continue testing these Django/SQLAlchemy versions on earlier Python versions. We can create an issue for this if we want to continue testing these versions.
