### PR TITLE
style: make isort compatible with black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ build-backend = "setuptools.build_meta"
 [tool.semantic_release]
 version_variable = "snapshot_queries/__init__.py:VERSION"
 branch = "main"
+
+[tool.isort]
+profile = "black"

--- a/tests/test_django/settings/settings.py
+++ b/tests/test_django/settings/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 from collections import OrderedDict
 

--- a/tests/test_sqlalchemy/snapshots/snap_test_postgres.py
+++ b/tests/test_sqlalchemy/snapshots/snap_test_postgres.py
@@ -4,13 +4,12 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots[
-    "TestPostgres::test_executing_queries 1"
-] = """Query 1
+snapshots['TestPostgres::test_executing_queries 1'] = '''Query 1
 ---------
-/python/tests/test_sqlalchemy/test_postgres.py:54 in test_executing_queries
+/python/tests/test_sqlalchemy/test_postgres.py:53 in test_executing_queries
 
 conn.execute(
 
@@ -20,7 +19,7 @@ VALUES (1, Juan, Gonzalez)
 
 Query 2
 ---------
-/python/tests/test_sqlalchemy/test_postgres.py:60 in test_executing_queries
+/python/tests/test_sqlalchemy/test_postgres.py:59 in test_executing_queries
 
 conn.execute(
 
@@ -30,7 +29,7 @@ VALUES (1, Computer Science 101, 2020-01-01)
 
 Query 3
 ---------
-/python/tests/test_sqlalchemy/test_postgres.py:66 in test_executing_queries
+/python/tests/test_sqlalchemy/test_postgres.py:65 in test_executing_queries
 
 conn.execute(self.students.select())
 
@@ -42,11 +41,11 @@ FROM students
 
 Query 4
 ---------
-/python/tests/test_sqlalchemy/test_postgres.py:67 in test_executing_queries
+/python/tests/test_sqlalchemy/test_postgres.py:66 in test_executing_queries
 
 conn.execute(self.classes.select())
 
 SELECT classes.id,
        classes.name,
        classes.start_date
-FROM classes"""
+FROM classes'''

--- a/tests/test_sqlalchemy/snapshots/snap_test_postgres.py
+++ b/tests/test_sqlalchemy/snapshots/snap_test_postgres.py
@@ -4,10 +4,11 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
-snapshots['TestPostgres::test_executing_queries 1'] = '''Query 1
+snapshots[
+    "TestPostgres::test_executing_queries 1"
+] = """Query 1
 ---------
 /python/tests/test_sqlalchemy/test_postgres.py:53 in test_executing_queries
 
@@ -48,4 +49,4 @@ conn.execute(self.classes.select())
 SELECT classes.id,
        classes.name,
        classes.start_date
-FROM classes'''
+FROM classes"""

--- a/tests/test_sqlalchemy/snapshots/snap_test_sqlite.py
+++ b/tests/test_sqlalchemy/snapshots/snap_test_sqlite.py
@@ -4,10 +4,11 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
-snapshots['TestSQLite::test_executing_queries 1'] = '''Query 1
+snapshots[
+    "TestSQLite::test_executing_queries 1"
+] = """Query 1
 ---------
 /python/tests/test_sqlalchemy/test_sqlite.py:46 in test_executing_queries
 
@@ -48,4 +49,4 @@ conn.execute(self.classes.select())
 SELECT classes.id,
        classes.name,
        classes.start_date
-FROM classes'''
+FROM classes"""

--- a/tests/test_sqlalchemy/snapshots/snap_test_sqlite.py
+++ b/tests/test_sqlalchemy/snapshots/snap_test_sqlite.py
@@ -4,13 +4,12 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
-snapshots[
-    "TestSQLite::test_executing_queries 1"
-] = """Query 1
+snapshots['TestSQLite::test_executing_queries 1'] = '''Query 1
 ---------
-/python/tests/test_sqlalchemy/test_sqlite.py:47 in test_executing_queries
+/python/tests/test_sqlalchemy/test_sqlite.py:46 in test_executing_queries
 
 conn.execute(
 
@@ -20,7 +19,7 @@ VALUES (1, 'Juan', 'Gonzalez')
 
 Query 2
 ---------
-/python/tests/test_sqlalchemy/test_sqlite.py:53 in test_executing_queries
+/python/tests/test_sqlalchemy/test_sqlite.py:52 in test_executing_queries
 
 conn.execute(
 
@@ -30,7 +29,7 @@ VALUES (1, 'Computer Science 101', '2020-01-01')
 
 Query 3
 ---------
-/python/tests/test_sqlalchemy/test_sqlite.py:59 in test_executing_queries
+/python/tests/test_sqlalchemy/test_sqlite.py:58 in test_executing_queries
 
 conn.execute(self.students.select())
 
@@ -42,11 +41,11 @@ FROM students
 
 Query 4
 ---------
-/python/tests/test_sqlalchemy/test_sqlite.py:60 in test_executing_queries
+/python/tests/test_sqlalchemy/test_sqlite.py:59 in test_executing_queries
 
 conn.execute(self.classes.select())
 
 SELECT classes.id,
        classes.name,
        classes.start_date
-FROM classes"""
+FROM classes'''

--- a/tests/test_sqlalchemy/test_postgres.py
+++ b/tests/test_sqlalchemy/test_postgres.py
@@ -1,8 +1,7 @@
 from datetime import date
 
 from snapshottest import TestCase
-from sqlalchemy import (Column, Date, Integer, MetaData, String, Table,
-                        create_engine)
+from sqlalchemy import Column, Date, Integer, MetaData, String, Table, create_engine
 
 from snapshot_queries import snapshot_queries
 

--- a/tests/test_sqlalchemy/test_sqlite.py
+++ b/tests/test_sqlalchemy/test_sqlite.py
@@ -2,8 +2,7 @@ from datetime import date
 from pathlib import Path
 
 from snapshottest import TestCase
-from sqlalchemy import (Column, Date, Integer, MetaData, String, Table,
-                        create_engine)
+from sqlalchemy import Column, Date, Integer, MetaData, String, Table, create_engine
 
 from snapshot_queries import snapshot_queries
 


### PR DESCRIPTION
## Changes

- Updates our `isort` settings to make it compatible with `black`. Followed the instructions on their docss
- Needed to reformat files for this change